### PR TITLE
Reversed sequence when loading trim values

### DIFF
--- a/OTTO_avoid/OTTO_avoid.ino
+++ b/OTTO_avoid/OTTO_avoid.ino
@@ -40,7 +40,7 @@ bool obstacleDetected = false;
 ///////////////////////////////////////////////////////////////////
 void setup(){
   //Set the servo pins
-  Otto.init(PIN_YL,PIN_YR,PIN_RL,PIN_RR,true, -1, -1, 8, 9);
+  Otto.init(PIN_YL,PIN_YR,PIN_RL,PIN_RR,true, -1, 10, 8, 9);
   Otto.sing(S_connection); //Otto wake up!
   Otto.home();
   delay(50);

--- a/OTTO_avoid/OTTO_avoid.ino
+++ b/OTTO_avoid/OTTO_avoid.ino
@@ -54,13 +54,13 @@ void loop() {
                Otto.sing(S_surprise); 
                Otto.playGesture(OttoFretful); 
                Otto.sing(S_fart3); 
-               Otto.walk(2,1300,-1); 
+               Otto.walk(2,1300,1); 
                Otto.turn(2,1000,-1);                
              delay(50); 
              obstacleDetector(); 
              }        
          else{ 
-            Otto.walk(1,1000,1); 
+            Otto.walk(1,1000,-1); 
             obstacleDetector(); 
         }           
   }  

--- a/libraries/Otto/Otto.cpp
+++ b/libraries/Otto/Otto.cpp
@@ -15,10 +15,10 @@
 
 void Otto::init(int YL, int YR, int RL, int RR, bool load_calibration, int NoiseSensor, int Buzzer, int USTrigger, int USEcho) {
   
-  servo_pins[0] = YL;
-  servo_pins[1] = YR;
-  servo_pins[2] = RL;
-  servo_pins[3] = RR;
+  servo_pins[3] = YL;
+  servo_pins[2] = YR;
+  servo_pins[1] = RL;
+  servo_pins[0] = RR;
 
   attachServos();
   isOttoResting=false;


### PR DESCRIPTION
Apparantly the sequence was reversed when loading the trim values from the EEPROM (tested with OTTO_avoid.ino)