### PR TITLE
Revert commit that broke the Otto library

### DIFF
--- a/libraries/Otto/Otto.h
+++ b/libraries/Otto/Otto.h
@@ -6,6 +6,7 @@
 #include <EEPROM.h>
 
 #include <US.h>
+#include <LedMatrix.h>
 #include <BatReader.h>
 
 #include "Otto_mouths.h"


### PR DESCRIPTION
This reverts commit 7fce5705e14b92c6b38b903a7c4f978b2783aed6.

There is a lot of code in the Otto library that is dependent on the LedMatrix library so of course removing this `#include` directive caused it to no longer compile:
```
In file included from C:\Users\per\Desktop\DIY-master\Otto_avoid\Otto_avoid.ino:10:0:

E:\electronics\arduino\libraries\Otto/Otto.h:97:5: error: 'LedMatrix' does not name a type

     LedMatrix ledmatrix;
```
Related: https://github.com/OttoDIY/DIY/issues/18#issuecomment-374512501